### PR TITLE
First draft of LICENSE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Samvera projects. Should be included. Minimal customization should be necessary.
 [CODE_OF_CONDUCT.md](./templates/CODE_OF_CONDUCT.md) - Should be included
 verbatim in every Samvera repository. If this is updated, it needs to be
 distributed to all Samvera organization repositories.
+
+[LICENSE](./templates/LICENSE) - Should be included in every Samvera
+repository. The copyright statements may change as appropriate. This template
+was taken from guidelines found on the
+[wiki](https://wiki.duraspace.org/display/samvera/Code+Copyright+Statement).

--- a/templates/LICENSE
+++ b/templates/LICENSE
@@ -1,0 +1,14 @@
+Copyright [yyyy] [name of copyright owner]
+Additional copyright may be held by others, as reflected in the commit history. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Closes #3

Hyrax has a long-form version of the Apache license, but our wiki says to do something different and the Apache docs seem to agree - so I think we should do that.

Apache docs: http://www.apache.org/licenses/LICENSE-2.0.html#apply